### PR TITLE
Fix reindex truncation

### DIFF
--- a/src/ai/embeddingService.ts
+++ b/src/ai/embeddingService.ts
@@ -36,7 +36,7 @@ export async function reindexAll(): Promise<void> {
     const embeddings = await embedTextBatch(texts);
     embeddings.forEach((vec, i) => {
       const note = items[i];
-      const combined = `${folderMap.get(note.parent_id) || ""} > ${note.title}\n\n${note.body}`;
+      const combined = `${folderMap.get(note.parent_id) || ""} > ${note.title}\n\n${note.body}`.slice(0, 2000);
       const entry: Entry = {
         id: note.id,
         embedding: normalize(vec),


### PR DESCRIPTION
## Summary
- match the upsert limit when storing reindexed notes

## Testing
- `npm run dist` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_688507a11cb8832788dff3441fbf96d8