### PR TITLE
Remove unused imports

### DIFF
--- a/src/ai/embeddingService.ts
+++ b/src/ai/embeddingService.ts
@@ -1,10 +1,8 @@
 import joplin from "api";
 import { embedText, embedTextBatch } from "./providers";
 import { normalize, cosineSimilarity } from "../models/math";
-const fs = require("fs").promises;
-const path = require("path");
 
-import { NoteMeta, FolderMeta, Entry, CacheFile } from "../models/interfaces";
+import { NoteMeta, FolderMeta, Entry } from "../models/interfaces";
 import { loadCache, saveCache, currentProvider, lastIndexedMap } from "../cache/cache";
 
 // Constants and in-memory state

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -1,4 +1,3 @@
-import joplin from "api";
 import { Ollama } from "ollama";
 import { normalize } from "../models/math";
 


### PR DESCRIPTION
## Summary
- clean up imports in providers and embeddingService

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68850793a8848327802ac59568467910